### PR TITLE
feat: fixed filter to ensure xprtnDtTm is optional.

### DIFF
--- a/src/logic.service.ts
+++ b/src/logic.service.ts
@@ -56,7 +56,7 @@ export const handleTransaction = async (req: unknown): Promise<void> => {
   // Filter in relevant dates
   conditions = conditions.filter((cond) => {
     return (
-      new Date(cond!.xprtnDtTm!) > transactionDate &&
+      (!cond!.xprtnDtTm || new Date(cond!.xprtnDtTm) > transactionDate) &&
       new Date(cond!.incptnDtTm) <= transactionDate
     );
   });


### PR DESCRIPTION
# SPDX-License-Identifier: Apache-2.0

## What did we change?

Adding optional logic to not check the xprtnDtTm property for a condition if it is not defined. Fixed line endings.

## Why are we doing this?

Because this field is optional, current behaviour will ignore the condition if it does not exist. Husky would not pass with the current line endings.

## How was it tested?
- [x] Locally
- [ ] Development Environment
- [ ] Not needed, changes very basic
- [x] Husky successfully run
- [x] Unit tests passing and Documentation done
