### PR TITLE
feat: Override fix

### DIFF
--- a/src/logic.service.ts
+++ b/src/logic.service.ts
@@ -122,7 +122,10 @@ export const determineOutcome = async (
     }
   }
 
-  if (conditions.some((cond) => cond.condTp === 'override')) {
+  if (
+    conditions.some((cond) => cond.condTp === 'override') &&
+    !conditions.some((cond) => cond.condTp === 'non-overridable-block')
+  ) {
     ruleResult.subRuleRef = 'override';
   }
 

--- a/src/logic.service.ts
+++ b/src/logic.service.ts
@@ -120,13 +120,10 @@ export const determineOutcome = async (
           );
         });
     }
-
-    return ruleResult;
   }
 
   if (conditions.some((cond) => cond.condTp === 'override')) {
     ruleResult.subRuleRef = 'override';
-    return ruleResult;
   }
 
   return ruleResult;


### PR DESCRIPTION
# SPDX-License-Identifier: Apache-2.0

## What did we change?

We removed returns that would block overridable blocks from triggering.

## Why are we doing this?

So override is possible.

## How was it tested?
- [X] Locally
- [X] Development Environment
- [ ] Not needed, changes very basic
- [X] Husky successfully run
- [X] Unit tests passing and Documentation done
