### PR TITLE
fix: Sidecar missing in deployment.yaml template

### DIFF
--- a/deployment.yaml
+++ b/deployment.yaml
@@ -28,6 +28,14 @@ spec:
               protocol: TCP
           resources: {}
           imagePullPolicy: Always
+        - name: event-flow-sidecar-rel-1-0-0
+          image: example.io/sidecar-rel-1-0-0:1.0.0
+          ports:
+            - name: http
+              protocol: TCP
+              containerPort: 5000
+          resources: {}
+          imagePullPolicy: Always
       restartPolicy: Always
       terminationGracePeriodSeconds: 30
       dnsPolicy: ClusterFirst


### PR DESCRIPTION
# SPDX-License-Identifier: Apache-2.0

## What did we change?
Add sidecar to the event-flow deployment.yaml

