### PR TITLE
build: bump @tazama-lf deps to rc and update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @Justus-at-Tazama @Sandy-at-Tazama @scott45
+* @tazama-lf/core-codeowners @tazama-lf/community-codeowners

--- a/VERSION
+++ b/VERSION
@@ -1,3 +1,0 @@
-# SPDX-License-Identifier: Apache-2.0
-
-v1.0.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "event-flow",
-  "version": "3.0.0",
+  "version": "4.0.0-rc.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "event-flow",
-      "version": "3.0.0",
+      "version": "4.0.0-rc.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@tazama-lf/frms-coe-lib": "6.0.0",
-        "@tazama-lf/frms-coe-startup-lib": "3.0.0"
+        "@tazama-lf/frms-coe-lib": "7.0.2-rc.2",
+        "@tazama-lf/frms-coe-startup-lib": "3.0.2-rc.2"
       },
       "devDependencies": {
         "@eslint-community/eslint-plugin-eslint-comments": "^4.5.0",
@@ -2135,9 +2135,9 @@
       }
     },
     "node_modules/@tazama-lf/frms-coe-lib": {
-      "version": "6.0.0",
-      "resolved": "https://npm.pkg.github.com/download/@tazama-lf/frms-coe-lib/6.0.0/43da7d6f911c00953831e0f59cd0fe2a43623c6b",
-      "integrity": "sha512-7QzbhD2TM6u4expnTwXni/NC1BRycsTN2p/LGPH13mugb3aOFng/0UHaj83v/WQ3P5QoHzSfqFQppx4RuVH3Mw==",
+      "version": "7.0.2-rc.2",
+      "resolved": "https://npm.pkg.github.com/download/@tazama-lf/frms-coe-lib/7.0.2-rc.2/5a47489d4d9a0154426dfe16d37e958c7ede24c5",
+      "integrity": "sha512-c8AXQpVPoRwxoQj1gMA9vEZN0AQEijp+6zXRb9ADToV1gMt+UbY0fmX+uFxmGrprB7OdP9N3YS5OPwD7if4MCw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@elastic/ecs-pino-format": "^1.5.0",
@@ -2150,6 +2150,7 @@
         "ioredis": "^5.7.0",
         "node-cache": "^5.1.2",
         "pg": "8.16.3",
+        "pg-format": "^1.0.4",
         "pino": "^9.9.0",
         "pino-elasticsearch": "^8.1.0",
         "protobufjs": "^7.5.4",
@@ -2157,16 +2158,16 @@
       }
     },
     "node_modules/@tazama-lf/frms-coe-startup-lib": {
-      "version": "3.0.0",
-      "resolved": "https://npm.pkg.github.com/download/@tazama-lf/frms-coe-startup-lib/3.0.0/ff86f7256d139056b942d831125becc51b6e1b17",
-      "integrity": "sha512-x7g0EOiCmR0FrqViz2MtMp9Tg4GOnruOB5PwX9pT1ps5aUfF6jp6NiNU4wRt/Y0x0sOYO4uXF/PIlAWVDCD/ew==",
+      "version": "3.0.2-rc.2",
+      "resolved": "https://npm.pkg.github.com/download/@tazama-lf/frms-coe-startup-lib/3.0.2-rc.2/4c73fb8b2186d6cb1ba927d6c6eede58d65e1c1d",
+      "integrity": "sha512-0puBZ+bWUjCxTO/wggn9dHRX5gxHvCXo/Z6w/Mw/ODY5pLqxOzSOv///OVZmgolFQ5s+iUCfDCnpX3tMOiSLoQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@google-cloud/bigquery": "^8.1.1",
         "@google-cloud/storage": "^7.16.0",
-        "@tazama-lf/frms-coe-lib": "6.0.0",
+        "@tazama-lf/frms-coe-lib": "7.0.2-rc.2",
         "amqplib": "0.10.6",
-        "axios": "^1.12.2",
+        "axios": "^1.13.5",
         "google-auth-library": "^10.2.0",
         "nats": "^2.29.3"
       }
@@ -3392,14 +3393,14 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.13.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.1.tgz",
-      "integrity": "sha512-hU4EGxxt+j7TQijx1oYdAjw4xuIp1wRQSsbMFwSthCWeBQur1eF+qJ5iQ5sN3Tw8YRzQNKb8jszgBdMDVqwJcw==",
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.14.0.tgz",
+      "integrity": "sha512-3Y8yrqLSwjuzpXuZ0oIYZ/XGgLwUIBU3uLvbcpb0pidD9ctpShJd43KSlEEkVQg6DS0G9NKyzOvBfUtDKEyHvQ==",
       "license": "MIT",
       "dependencies": {
-        "follow-redirects": "^1.15.6",
-        "form-data": "^4.0.4",
-        "proxy-from-env": "^1.1.0"
+        "follow-redirects": "^1.15.11",
+        "form-data": "^4.0.5",
+        "proxy-from-env": "^2.1.0"
       }
     },
     "node_modules/babel-jest": {
@@ -5676,9 +5677,9 @@
       }
     },
     "node_modules/form-data": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
-      "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
@@ -8923,6 +8924,15 @@
       "integrity": "sha512-nkc6NpDcvPVpZXxrreI/FOtX3XemeLl8E0qFr6F2Lrm/I8WOnaWNhIPK2Z7OHpw7gh5XJThi6j6ppgNoaT1w4w==",
       "license": "MIT"
     },
+    "node_modules/pg-format": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/pg-format/-/pg-format-1.0.4.tgz",
+      "integrity": "sha512-YyKEF78pEA6wwTAqOUaHIN/rWpfzzIuMh9KdAhc3rSLQ/7zkRFcCgYBAEGatDstLyZw4g0s9SNICmaTGnBVeyw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
     "node_modules/pg-int8": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
@@ -9289,10 +9299,13 @@
       }
     },
     "node_modules/proxy-from-env": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
-      "license": "MIT"
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/pump": {
       "version": "3.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "event-flow",
-  "version": "3.0.0",
+  "version": "4.0.0-rc.0",
   "description": "Event flow control processor for tazama",
   "keywords": [
     "tazama"
@@ -32,8 +32,8 @@
     "prepare": "husky"
   },
   "dependencies": {
-    "@tazama-lf/frms-coe-lib": "6.0.0",
-    "@tazama-lf/frms-coe-startup-lib": "3.0.0"
+    "@tazama-lf/frms-coe-lib": "7.0.2-rc.2",
+    "@tazama-lf/frms-coe-startup-lib": "3.0.2-rc.2"
   },
   "devDependencies": {
     "@eslint-community/eslint-plugin-eslint-comments": "^4.5.0",


### PR DESCRIPTION
## Summary

Bumps @tazama-lf dependencies to latest rc versions and updates repo housekeeping.

### Dependency updates

| Package | From | To |
|---------|------|----|
| @tazama-lf/frms-coe-lib | 6.0.0 | 7.0.2-rc.2 |
| @tazama-lf/frms-coe-startup-lib | 3.0.0 | 3.0.2-rc.2 |

### Version bump

3.0.0 -> 4.0.0-rc.0

### CI changes

- Removed CHANGELOG.md and VERSION (if present)
- Updated .github/CODEOWNERS: * @tazama-lf/core-codeowners @tazama-lf/community-codeowners